### PR TITLE
5/5 about headshots visible

### DIFF
--- a/src/components/about/about.js
+++ b/src/components/about/about.js
@@ -35,6 +35,7 @@ export default function About() {
                 src={badassHeadshot}
                 alt="Bad-ass Headshot"
                 delay={1}
+                className="about-desktop"
               />
             </div>
             <div className="mr-auto w-44 flex-none space-y-8 sm:mr-0 sm:pt-52 lg:pt-36">
@@ -44,6 +45,12 @@ export default function About() {
                 delay={0}
               />
               <AboutImage src={bestHeadshot} alt="Lovable Headshot" delay={4} />
+              <AboutImage
+                src={badassHeadshot}
+                alt="Bad-ass Headshot"
+                delay={1}
+                className="about-mobile"
+              />
             </div>
             <div className="w-44 flex-none space-y-8 pt-32 sm:pt-0">
               <AboutImage

--- a/src/components/about/aboutImage.css
+++ b/src/components/about/aboutImage.css
@@ -1,0 +1,12 @@
+.about-mobile {
+  display: none;
+}
+
+@media screen and (max-width: 560px) {
+  .about-mobile {
+    display: block;
+  }
+  .about-desktop {
+    display: none;
+  }
+}

--- a/src/components/about/aboutImage.js
+++ b/src/components/about/aboutImage.js
@@ -1,12 +1,13 @@
 import { motion } from "framer-motion";
+import "./aboutImage.css";
 
-export default function AboutImage({ src, alt, delay }) {
+export default function AboutImage({ src, alt, delay, className }) {
   return (
     <motion.div
-      className="relative overflow-hidden rounded-xl"
+      className={`relative overflow-hidden rounded-xl ${className}`}
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
-      viewport={{ once: true }}
+      viewport={{ once: true, threshold: 0.2 }}
       transition={{ duration: 0.5, delay: delay * 0.2 }}
     >
       <motion.img


### PR DESCRIPTION
# Fix About Images

## Objective
Correctly show all 5 headshot on the About page

## Changes Made
- Added 'className' property to AboutImage component
- Added responsive CSS rules for about-image / about-desktop

## Screenshots (if applicable)
Before | After
--- | ---
![Screenshot 2024-02-11 103232](https://github.com/Nukambe/moriahyoung-react-app/assets/19686923/b673566c-2130-4ae5-9586-b33d0153cefb) | ![Screenshot 2024-02-11 103156](https://github.com/Nukambe/moriahyoung-react-app/assets/19686923/cf0348df-fd48-4c35-a8e7-883ed1112442)

## Related Issues
- #7 