### PR TITLE
Fix Stretched Main Image on iPhones with Mobile-Only Hero Component

### DIFF
--- a/src/components/home/home.js
+++ b/src/components/home/home.js
@@ -2,36 +2,50 @@ import HomeButton from "./homeButton";
 import headshot from "../../assets/content/0463-_Moriah_Young-_Larger_File.jpg";
 import { motion } from "framer-motion";
 import SocialLinks from "../socials/socials";
+import HomeHero from "./homeHero";
 
 export default function Home() {
   return (
-    <div className="flex flex-col lg:flex-row justify-between items-center bg-rose-50 w-full h-full">
-      <div className="px-8 lg:min-w-[300px] lg:max-w-[400px] xl:min-w-[672px]">
-        <h1 className="mt-24 text-4xl font-bold tracking-tight text-rose-900 sm:mt-10 sm:text-6xl">
-          Moriah Young
-        </h1>
-        <SocialLinks className="w-full text-3xl flex gap-8 text-rose-700 my-8 pl-2" />
-        <p className="mt-6 text-lg leading-8 text-gray-600">
-          Welcome to the virtual home of a woman who thrives off the
-          entertainment of others. Moriah Young is a voice over artist and on
-          screen talent who loves little more than bringing smiles, joy and
-          thought provoking emotions out of people. Please make yourself at home
-          (browse) and see what she’s all about!
-        </p>
-        <div className="mt-10 flex items-center gap-x-6">
-          <HomeButton text="Voice Work" link="/voice" />
-          <HomeButton text="On-Camera Work" link="/oncamera" />
+    <>
+      <div className="hidden md:flex flex-col lg:flex-row justify-between items-center bg-rose-50 w-full h-full">
+        <HomeContent titleColor="rose-900" textColor="gray-600" />
+        <div className="p-8 lg:p-0 h-full">
+          <motion.img
+            initial={{ opacity: 0, x: 200 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 1 }}
+            className="shadow-xl lg:object-cover h-full"
+            src={headshot}
+            alt="Headshot"
+          />
         </div>
       </div>
-      <div className="p-8 lg:p-0 h-full">
-        <motion.img
-          initial={{ opacity: 0, x: 200 }}
-          animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 1 }}
-          className="shadow-xl lg:object-cover h-full"
-          src={headshot}
-          alt="Headshot"
-        />
+      <HomeHero>
+        <HomeContent titleColor="white" textColor="white" />
+      </HomeHero>
+    </>
+  );
+}
+
+function HomeContent({ titleColor, textColor }) {
+  return (
+    <div className="px-8 lg:min-w-[300px] lg:max-w-[400px] xl:min-w-[672px]">
+      <h1
+        className={`mt-24 text-4xl font-bold tracking-tight text-${titleColor} sm:mt-10 sm:text-6xl`}
+      >
+        Moriah Young
+      </h1>
+      <SocialLinks className="w-full text-3xl flex gap-8 text-rose-700 my-8 p-0" />
+      <p className={`mt-6 text-lg leading-8 text-${textColor}`}>
+        Welcome to the virtual home of a woman who thrives off the entertainment
+        of others. Moriah Young is a voice over artist and on screen talent who
+        loves little more than bringing smiles, joy and thought provoking
+        emotions out of people. Please make yourself at home (browse) and see
+        what she’s all about!
+      </p>
+      <div className="mt-10 flex items-center gap-x-6">
+        <HomeButton text="Voice Work" link="/voice" />
+        <HomeButton text="On-Camera Work" link="/oncamera" />
       </div>
     </div>
   );

--- a/src/components/home/homeHero.js
+++ b/src/components/home/homeHero.js
@@ -1,0 +1,20 @@
+import headshot from "../../assets/content/0463-_Moriah_Young-_Larger_File.jpg";
+
+export default function HomeHero({ children }) {
+  return (
+    <div
+      className="md:hidden overflow-hidden"
+      style={{
+        backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(${headshot})`,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        backgroundRepeat: "no-repeat",
+        position: "relative",
+        height: "100%",
+        width: "100%",
+      }}
+    >
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/src/components/socials/socials.js
+++ b/src/components/socials/socials.js
@@ -29,7 +29,7 @@ const socials = [
 ];
 
 export default function SocialLinks({
-  className = "mx-auto w-96 text-4xl flex justify-evenly text-rose-800",
+  className = "mx-auto w-96 text-4xl flex justify-evenly text-rose-800 p-0",
   size = 48,
 }) {
   return (


### PR DESCRIPTION
# Fix Stretched Main Image on iPhones with Mobile-Only Hero Component

## Description
This PR addresses the issue where the main image on the homepage was stretched when viewed on iPhone devices. By introducing a mobile-only Hero component that utilizes the image as a CSS background, we ensure a consistent and visually appealing experience across all mobile devices, particularly improving the display on iPhones.

## Changes Made
- Developed a new Hero component tailored for mobile devices, utilizing Tailwind CSS for responsive design.
- Set the main homepage image as a background image within the new Hero component to prevent stretching and distortion.
- Implemented media queries to only activate the mobile-only Hero component on screen sizes corresponding to mobile devices, ensuring desktop displays remain unaffected.

## How to Test
1. Checkout to this branch.
2. Start the development server with ```npm start```.
3. Open the homepage on various devices, including several iPhone models, to observe the improved image display.
4. Verify that the image maintains its aspect ratio without stretching on all screen sizes.

## Screenshot
![Screenshot 2024-02-11 165421](https://github.com/Nukambe/moriahyoung-react-app/assets/19686923/a2fe03f8-3d07-4609-bc5c-b06befffd73e)

Relevant Issues
Fixes #10 

Additional Notes
This solution has been implemented to specifically target mobile devices without altering the desktop experience. Further adjustments can be made based on feedback and additional testing on other devices.